### PR TITLE
Update MosDNS

### DIFF
--- a/luci-app-mosdns/root/etc/init.d/MosDNS
+++ b/luci-app-mosdns/root/etc/init.d/MosDNS
@@ -57,6 +57,8 @@ prepare_setting() {
   uci commit passwall
   uci set vssr.@global[0].pdnsd_enable='0'
   uci commit vssr
+  ipset -! add blacklist 8.8.4.4
+  ipset -! add blacklist 1.0.0.1
 }
 
 restart_others() {


### PR DESCRIPTION
把dns压入ipset使得解析时经过代理、确保得到对代理节点最优的ip