### PR TITLE
Update config.yaml

### DIFF
--- a/luci-app-mosdns/root/etc/mosdns/config.yaml
+++ b/luci-app-mosdns/root/etc/mosdns/config.yaml
@@ -62,9 +62,9 @@ plugin:
     args:
       upstream:
         - addr:            'tls://8.8.4.4'
-          idle_timeout:    60
+          idle_timeout:    10
         - addr:            'tls://101.101.101.101'
-          idle_timeout:    30
+          idle_timeout:    10
 
   - tag:                   lazy_cache
     type:                  cache


### PR DESCRIPTION
不确定是不是所有 openwrt 的 bug 还是有意而为之。我这里发现重启 pppoe 的 interface 不会切断 mosdns 的连接，导致虽然 interface 已重启有网，但是 fforward 一直用失效的连接直到 idle_timeout。就好像断网了 idle_timeout 秒。

调低以求稳。10s 对于个人用户来说复用率也能很高了。