### PR TITLE
Change passwall's DNS setting method

### DIFF
--- a/luci-app-mosdns/root/etc/mosdns/set.sh
+++ b/luci-app-mosdns/root/etc/mosdns/set.sh
@@ -2,9 +2,10 @@
 uci set shadowsocksr.@global[0].pdnsd_enable='0'
 uci del shadowsocksr.@global[0].tunnel_forward
 uci commit shadowsocksr
-uci set passwall.@global[0].dns_mode='nonuse'
-uci del passwall.@global[0].dns_forward
+uci set passwall.@global[0].dns_mode='udp'
+uci set passwall.@global[0].dns_forward='127.0.0.1'
 uci del passwall.@global[0].dns_cache
+uci set passwall.@global[0].chinadns_ng='0'
 uci commit passwall
 uci set vssr.@global[0].pdnsd_enable='0'
 uci commit vssr

--- a/luci-app-mosdns/root/etc/mosdns/unset.sh
+++ b/luci-app-mosdns/root/etc/mosdns/unset.sh
@@ -5,6 +5,7 @@ uci commit shadowsocksr
 uci set passwall.@global[0].dns_mode='pdnsd'
 uci set passwall.@global[0].dns_forward='8.8.8.8'
 uci set passwall.@global[0].dns_cache='1'
+uci set passwall.@global[0].chinadns_ng='1'
 uci commit passwall
 uci set vssr.@global[0].pdnsd_enable='1'
 uci commit vssr


### PR DESCRIPTION
Because "nonuse DNS option" have been removed in passwall 4.47