### PR TITLE
apple cdn

### DIFF
--- a/luci-app-mosdns/luasrc/view/mosdns/mosdns_log.htm
+++ b/luci-app-mosdns/luasrc/view/mosdns/mosdns_log.htm
@@ -8,6 +8,7 @@
 					log_textarea.innerHTML = "";
 					log_textarea.scrollTop = log_textarea.scrollHeight;
 				}
+				location.reload();
 			}
 		);
 	}

--- a/luci-app-mosdns/root/etc/mosdns/def_config.yaml
+++ b/luci-app-mosdns/root/etc/mosdns/def_config.yaml
@@ -107,6 +107,7 @@ plugin:
     args:
       domain:
         - "ext:/usr/share/v2ray/geosite.dat:cn"
+        - "ext:/usr/share/v2ray/geosite.dat:apple-cn"
 
   - tag: query_is_non_local_domain
     type: query_matcher


### PR DESCRIPTION
在另一个仓库pick过来的。实测可以解决macos  iphone 听音乐下软件慢的问题

日志页面点击清空按钮自动刷新页面，可以同时把浏览器已经显示的日志给清除