### PR TITLE
luci-app-mosdns: mosupdater.sh: 解决数据库更新可能会出现的问题

### DIFF
--- a/luci-app-mosdns/root/etc/mosdns/mosupdater.sh
+++ b/luci-app-mosdns/root/etc/mosdns/mosupdater.sh
@@ -8,16 +8,13 @@ TMPDIR=$(mktemp -d) || exit 1
 #wget https://cdn.jsdelivr.net/gh/QiuSimons/openwrt-mos@master/luci-app-mosdns/root/etc/mosdns/geoip.dat -nv -O /tmp/mosdns/geoip.dat
 #wget https://cdn.jsdelivr.net/gh/QiuSimons/openwrt-mos@master/luci-app-mosdns/root/etc/mosdns/geosite.dat -nv -O /tmp/mosdns/geosite.dat
 #wget https://cdn.jsdelivr.net/gh/QiuSimons/openwrt-mos@master/luci-app-mosdns/root/etc/mosdns/serverlist.txt -nv -O /tmp/mosdns/serverlist.txt
-getdat geoip.dat
-getdat geosite.dat
-if [ "$(grep -o CN "$TMPDIR"/geoip.dat | wc -l)" -eq "0" ]; then
-  rm -rf "$TMPDIR"/geoip.dat
+getdat geoip.dat && getdat geosite.dat
+if [ $? -ne 0 ]; then
+	rm -rf "$TMPDIR"
+else
+	cp -rf "$TMPDIR"/* /usr/share/v2ray
+	rm -rf "$TMPDIR"
 fi
-if [ "$(grep -o .com "$TMPDIR"/geosite.dat | wc -l)" -lt "1000" ]; then
-  rm -rf "$TMPDIR"/geosite.dat
-fi
-cp -rf "$TMPDIR"/* /usr/share/v2ray
-rm -rf "$TMPDIR"
 
 syncconfig=$(uci -q get mosdns.mosdns.syncconfig)
 if [ "$syncconfig" -eq 1 ]; then


### PR DESCRIPTION
* geodata 会在某些 openwrt 版本上被识别成二进制文件，这会让 grep 出错（binary file matches），在 bash -e 条件下会导致 “配置同步”、“AD列表更新” 操作终止
* 通过正常退出值判断 geodata 更新是否成功可以解决这种问题