### PR TITLE
luci-app-mosdns: fix logpath reading

### DIFF
--- a/luci-app-mosdns/root/etc/mosdns/lib.sh
+++ b/luci-app-mosdns/root/etc/mosdns/lib.sh
@@ -14,7 +14,7 @@ logfile_path() (
     uci -q get mosdns.mosdns.logfile
   else
     [ ! -f /etc/mosdns/cus_config.yaml ] && exit 1
-    grep -A 4 log /etc/mosdns/cus_config.yaml | grep file | awk -F ":" '{print $2}' | sed 's/\"//g;s/ //g'
+    awk '/^log:/{f=1;next}f==1{if($0~/file:/){print;exit}if($0~/^[^ ]/)exit}' /etc/mosdns/cus_config.yaml | grep -Eo "/[^'\"]+"
   fi
 )
 


### PR DESCRIPTION
自定义配置文件非常多元化，有些包含注释符，有些没有换行符，无法控制日志文件路径使用在 log 字符出现的4行内。这个提交解决不同配置文件下日志文件始终正确读取

```yaml
....
log:
   ...
  file: "/xxx.log"
  file: '/xxx.log'
  file: /xxx.log
  or not set
  ...

xxx:
  ...
  file: xxx # won't match here
```