### PR TITLE
添加编译脚本

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 cp feeds.conf.default feeds.conf
 echo "src-link QiuSimons /home/build/openwrt/QiuSimons" >> ./feeds.conf
-sudo apt update
-sudo apt install upx -y
-cp /usr/bin/upx /home/build/openwrt/staging_dir/host/bin/
-cp /usr/bin/upx-ucl /home/build/openwrt/staging_dir/host/bin/
 
 ./scripts/feeds update QiuSimons
 ./scripts/feeds update packages

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,7 @@ echo "src-link QiuSimons /home/build/openwrt/QiuSimons" >> ./feeds.conf
 ./scripts/feeds update QiuSimons
 ./scripts/feeds update packages
 make defconfig
-./scripts/feeds install -a -p QiuSimons
-./scripts/feeds install -a -p packages
+./scripts/feeds install -p QiuSimons -f mosdns
 
 make package/mosdns/download V=s
 make package/mosdns/check V=s

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+cp feeds.conf.default feeds.conf
+echo "src-link QiuSimons /home/build/openwrt/QiuSimons" >> ./feeds.conf
+sudo apt update
+sudo apt install upx -y
+cp /usr/bin/upx /home/build/openwrt/staging_dir/host/bin/
+cp /usr/bin/upx-ucl /home/build/openwrt/staging_dir/host/bin/
+
+./scripts/feeds update QiuSimons
+./scripts/feeds update packages
+make defconfig
+./scripts/feeds install -a -p QiuSimons
+./scripts/feeds install -a -p packages
+
+make package/mosdns/download V=s
+make package/mosdns/check V=s
+make package/mosdns/compile V=s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  sdk:
+    image: openwrtorg/sdk:x86_64-openwrt-22.03
+    volumes:
+      - .:/home/build/openwrt/QiuSimons/mosdns
+      - ./bin:/home/build/openwrt/bin
+      - ./build.sh:/home/build/openwrt/build.sh
+    command: /home/build/openwrt/build.sh
+      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 services:
-  sdk:
+  x86_64:
     image: openwrtorg/sdk:x86_64-openwrt-22.03
+    volumes:
+      - .:/home/build/openwrt/QiuSimons/mosdns
+      - ./bin:/home/build/openwrt/bin
+      - ./build.sh:/home/build/openwrt/build.sh
+    command: /home/build/openwrt/build.sh
+  aarch64:
+    image: openwrtorg/sdk:aarch64_generic-22.03.3
     volumes:
       - .:/home/build/openwrt/QiuSimons/mosdns
       - ./bin:/home/build/openwrt/bin


### PR DESCRIPTION
添加了一个编译脚本，简单起见用了 Docker 启动编译环境

使用方式

```bash
docker-compose up x86_64

or

docker-compose up aarch64
```

包在当前目录的 bin 下面

docker-compose 也可以方便的跑在 GitHub Action 中，想改造的话可以改造一下

不过个人觉得更好的方式是使用 https://github.com/openwrt/gh-action-sdk
示例 https://github.com/EkkoG/openwrt-dist/blob/master/.github/workflows/main.yml

但是还没有测试通过 https://github.com/EkkoG/openwrt-dist/actions/runs/4427762597

另外由于 OpenWrt 的 golang 环境不是很灵活，所以我觉得可以更好的方式是由 mosdns 项目提供预编译二进制，然后 openwrt 包只是简单的下载复制，类似这个项目 https://github.com/frainzy1477/clash/blob/master/Makefile

mosdns 已经有提供预编译二进制，所以改造应该不难

以上