### PR TITLE
mosdns: drop `upx/host` build depends

### DIFF
--- a/mosdns/Makefile
+++ b/mosdns/Makefile
@@ -20,7 +20,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_MOSDNS_COMPRESS_GOPROXY \
 	CONFIG_MOSDNS_COMPRESS_UPX
 
-PKG_BUILD_DEPENDS:=golang/host upx/host
+PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
@@ -56,7 +56,7 @@ config MOSDNS_COMPRESS_GOPROXY
 
 config MOSDNS_COMPRESS_UPX
 	bool "Compress executable files with UPX"
-	default y
+	default n
 endef
 
 ifeq ($(CONFIG_MOSDNS_COMPRESS_GOPROXY),y)


### PR DESCRIPTION
* upx has been removed by the openwrt project a long time ago.
* https://github.com/openwrt/openwrt/commit/0685f2a66cbb4d39417f168cfb37ae6fa7dbf6cb