### PR TITLE
luci-app-mosdns: init.d: sent terminate signal by procd

### DIFF
--- a/luci-app-mosdns/root/etc/init.d/mosdns
+++ b/luci-app-mosdns/root/etc/init.d/mosdns
@@ -137,7 +137,6 @@ start_service() {
 
 stop_service() {
 
-  pgrep -f /usr/bin/mosdns | xargs kill -9
   echo "MosDNS turn off"
   echo "enabled=$enabled"
 


### PR DESCRIPTION
* fix stop service cannot dump cache