### PR TITLE
一些配置改进

### DIFF
--- a/luci-app-mosdns/luasrc/model/cbi/mosdns/rule_list.lua
+++ b/luci-app-mosdns/luasrc/model/cbi/mosdns/rule_list.lua
@@ -4,6 +4,7 @@ local white_list_file = "/etc/mosdns/rule/whitelist.txt"
 local block_list_file = "/etc/mosdns/rule/blocklist.txt"
 local hosts_list_file = "/etc/mosdns/rule/hosts.txt"
 local redirect_list_file = "/etc/mosdns/rule/redirect.txt"
+local ddns_list_file = "/etc/mosdns/rule/ddnslist.txt"
 local cus_config_file = "/etc/mosdns/cus_config.yaml"
 
 m = Map("mosdns")
@@ -13,6 +14,7 @@ s.anonymous = true
 
 s:tab("white_list", translate("White Lists"))
 s:tab("block_list", translate("Block Lists"))
+s:tab("ddns_list", translate("DDNS Lists"))
 s:tab("hosts_list", translate("Hosts"))
 s:tab("redirect_list", translate("Redirect"))
 s:tab("cus_config", translate("Cus Config"))
@@ -33,6 +35,16 @@ o.wrap = "off"
 o.cfgvalue = function(self, section) return nixio.fs.readfile(block_list_file) or "" end
 o.write = function(self, section, value) nixio.fs.writefile(block_list_file, value:gsub("\r\n", "\n")) end
 o.remove = function(self, section, value) nixio.fs.writefile(block_list_file, "") end
+o.validate = function(self, value)
+    return value
+end
+
+o = s:taboption("ddns_list", TextValue, "ddns", "", "<font color='red'>" .. translate("These domains are always resolved using local DNS. And force TTL 5 seconds, DNS resolution results will not enter the cache. For example: myddns.example.com.") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
+o.rows = 15
+o.wrap = "off"
+o.cfgvalue = function(self, section) return nixio.fs.readfile(ddns_list_file) or "" end
+o.write = function(self, section, value) nixio.fs.writefile(ddns_list_file, value:gsub("\r\n", "\n")) end
+o.remove = function(self, section, value) nixio.fs.writefile(ddns_list_file, "") end
 o.validate = function(self, value)
     return value
 end

--- a/luci-app-mosdns/po/zh-cn/mosdns.po
+++ b/luci-app-mosdns/po/zh-cn/mosdns.po
@@ -136,6 +136,12 @@ msgstr "黑名单"
 msgid "These domains are blocked from DNS resolution. Please input the domain names of websites, every line can input only one website domain. For example: baidu.com."
 msgstr "加入的域名将屏蔽 DNS 解析（每个域名一行，允许使用规则匹配）"
 
+msgid "DDNS Lists"
+msgstr "DDNS 域名"
+
+msgid "These domains are always resolved using local DNS. And force TTL 5 seconds, DNS resolution results will not enter the cache. For example: myddns.example.com."
+msgstr "加入的域名始终使用 “本地 DNS” 进行解析，并且强制 TTL 5 秒，解析结果不会进入缓存（每个域名一行，支持域名匹配规则）"
+
 msgid "Hosts For example: baidu.com 10.0.0.1"
 msgstr "自定义 Hosts 重写，如：baidu.com 10.0.0.1（每个规则一行）"
 

--- a/luci-app-mosdns/root/etc/init.d/mosdns
+++ b/luci-app-mosdns/root/etc/init.d/mosdns
@@ -137,7 +137,6 @@ start_service() {
 
 stop_service() {
 
-  pgrep -f /usr/bin/mosdns | xargs kill -9
   echo "MosDNS turn off"
   echo "enabled=$enabled"
 

--- a/luci-app-mosdns/root/etc/mosdns/def_config_orig.yaml
+++ b/luci-app-mosdns/root/etc/mosdns/def_config_orig.yaml
@@ -42,6 +42,13 @@ plugins:
       files:                        # 从文本文件载入
         - "/etc/mosdns/rule/blocklist.txt"
 
+  # DDNS域名 加入的域名强制 TTL 5 且不进行缓存
+  - tag: ddnslist
+    type: domain_set
+    args:
+      files:                        # 从文本文件载入
+        - "/etc/mosdns/rule/ddnslist.txt"
+
   # 自定义 Hosts 重写
   - tag: hosts
     type: hosts
@@ -102,11 +109,13 @@ plugins:
     args:
       - exec: prefer_ipv4
       - exec: $forward_remote
-  
+
   # 有响应终止返回
   - tag: has_resp_sequence
     type: sequence
     args:
+      - matches: qname $ddnslist
+        exec: ttl 5-5
       - matches: has_resp
         exec: accept
 
@@ -148,6 +157,13 @@ plugins:
       - matches: qname $geosite_no_cn
         exec: $remote_sequence
 
+  # 查询 DDNS 域名
+  - tag: query_is_ddns_domain
+    type: sequence
+    args:
+      - matches: qname $ddnslist
+        exec: $local_sequence
+
   # 查询白名单
   - tag: query_is_whitelist_domain
     type: sequence
@@ -178,10 +194,13 @@ plugins:
       - exec: $hosts
       - exec: jump has_resp_sequence
       - matches:
+        - "!qname $ddnslist"
         - "!qname $blocklist"
         - "!qname $adlist"
         exec: $cache
       - exec: $redirect
+      - exec: jump has_resp_sequence
+      - exec: $query_is_ddns_domain
       - exec: jump has_resp_sequence
       - exec: $query_is_whitelist_domain
       - exec: jump has_resp_sequence

--- a/luci-app-mosdns/root/etc/mosdns/def_config_orig.yaml
+++ b/luci-app-mosdns/root/etc/mosdns/def_config_orig.yaml
@@ -154,7 +154,6 @@ plugins:
     args:
       - matches: qname $whitelist
         exec: $local_sequence
-      - exec: jump has_resp_sequence
 
   # 拒绝名单
   - tag: query_is_reject_domain
@@ -178,11 +177,15 @@ plugins:
     args:
       - exec: $hosts
       - exec: jump has_resp_sequence
+      - matches:
+        - "!qname $blocklist"
+        - "!qname $adlist"
+        exec: $cache
       - exec: $redirect
       - exec: jump has_resp_sequence
       - exec: $query_is_whitelist_domain
+      - exec: jump has_resp_sequence
       - exec: $query_is_reject_domain
-      - exec: $cache
       - exec: jump has_resp_sequence
       - exec: $query_is_local_domain
       - exec: jump has_resp_sequence


### PR DESCRIPTION
https://github.com/QiuSimons/openwrt-mos/commit/93d0ff14ac5836dab477e21232162d3c123e2716 ：使规则列表正常使用缓存

https://github.com/QiuSimons/openwrt-mos/commit/5ae522e7c38d8b9d962f249250012e0d9c448fce ：使用 `kill` 命令杀死进程会导致 mosdns 关闭前无法 dump cache，而配置文件中 `dump_interval` 的值为 12 小时，在这期间调整参数、重启mosdns都会导致这段时间内的缓存丢失。不再使用 kill，让 openwrt 默认的 procd 来结束进程解决这个问题

https://github.com/QiuSimons/openwrt-mos/commit/0afb1ad3e9cc1a843a50c16d3b65ec0c38908d1f ： 添加一个 DDNS 域名列表，强制该列表 ttl 为 5秒，且不进行缓存操作。避免（ [mosdns cache](https://irine-sistiana.gitbook.io/mosdns-wiki/mosdns-v5/ru-he-pei-zhi-mosdns/ke-zhi-hang-cha-jian#cache) 文档提及的缺点：可能影响 DNS 更新频繁的域名正常使用，比如 DDNS，CDN）