### PR TITLE
重构

### DIFF
--- a/luci-app-mosdns/luasrc/controller/mosdns.lua
+++ b/luci-app-mosdns/luasrc/controller/mosdns.lua
@@ -1,34 +1,101 @@
 module("luci.controller.mosdns", package.seeall)
 
+local function check_config_file()
+    return nixio.fs.access("/etc/config/mosdns")
+end
+
+local function prepare_content(content_type)
+    luci.http.prepare_content(content_type)
+end
+
+local function write_json(data)
+    luci.http.write_json(data)
+end
+
+local function write_file_content(file_path)
+    luci.http.write(luci.sys.exec("cat " .. file_path))
+end
+
+local function clear_file_content(file_path)
+    luci.sys.call("true > " .. file_path)
+end
+
+local function is_mosdns_running()
+    return luci.sys.call("pgrep -f mosdns >/dev/null") == 0
+end
+
 function index()
-	if not nixio.fs.access("/etc/config/mosdns") then
-		return
-	end
-	
-	local page = entry({"admin", "services", "mosdns"}, alias("admin", "services", "mosdns", "basic"), _("MosDNS"), 30)
-	page.dependent = true
-	page.acl_depends = { "luci-app-mosdns" }
-	
-	entry({"admin", "services", "mosdns", "basic"}, cbi("mosdns/basic"), _("Basic Setting"), 1).leaf = true
-	entry({"admin", "services", "mosdns", "rule_list"}, cbi("mosdns/rule_list"), _("Rule List"), 2).leaf = true
-	entry({"admin", "services", "mosdns", "update"}, cbi("mosdns/update"), _("Geodata Update"), 3).leaf = true
-	entry({"admin", "services", "mosdns", "log"}, cbi("mosdns/log"), _("Logs"), 4).leaf = true
-	entry({"admin", "services", "mosdns", "status"}, call("act_status")).leaf = true
-	entry({"admin", "services", "mosdns", "get_log"}, call("get_log")).leaf = true
-	entry({"admin", "services", "mosdns", "clear_log"}, call("clear_log")).leaf = true
+    if not check_config_file() then
+        return
+    end
+
+    local mosdns_page = entry(
+        {"admin", "services", "mosdns"},
+        alias("admin", "services", "mosdns", "basic"),
+        _("MosDNS"),
+        30
+    )
+    mosdns_page.dependent = true
+    mosdns_page.acl_depends = { "luci-app-mosdns" }
+
+    entry(
+        {"admin", "services", "mosdns", "basic"},
+        cbi("mosdns/basic"),
+        _("Basic Setting"),
+        1
+    ).leaf = true
+
+    entry(
+        {"admin", "services", "mosdns", "rule_list"},
+        cbi("mosdns/rule_list"),
+        _("Rule List"),
+        2
+    ).leaf = true
+
+    entry(
+        {"admin", "services", "mosdns", "update"},
+        cbi("mosdns/update"),
+        _("Geodata Update"),
+        3
+    ).leaf = true
+
+    entry(
+        {"admin", "services", "mosdns", "log"},
+        cbi("mosdns/log"),
+        _("Logs"),
+        4
+    ).leaf = true
+
+    entry(
+        {"admin", "services", "mosdns", "status"},
+        call("act_status")
+    ).leaf = true
+
+    entry(
+        {"admin", "services", "mosdns", "get_log"},
+        call("get_log")
+    ).leaf = true
+
+    entry(
+        {"admin", "services", "mosdns", "clear_log"},
+        call("clear_log")
+    ).leaf = true
 end
 
 function act_status()
-	local e = {}
-	e.running = luci.sys.call("pgrep -f mosdns >/dev/null") == 0
-	luci.http.prepare_content("application/json")
-	luci.http.write_json(e)
+    local status = {
+        running = is_mosdns_running()
+    }
+    prepare_content("application/json")
+    write_json(status)
 end
 
 function get_log()
-	luci.http.write(luci.sys.exec("cat $(/etc/mosdns/lib.sh logfile)"))
+    local log_file_path = luci.sys.exec("/etc/mosdns/lib.sh logfile")
+    write_file_content(log_file_path)
 end
 
 function clear_log()
-	luci.sys.call("true > $(/etc/mosdns/lib.sh logfile)")
+    local log_file_path = luci.sys.exec("/etc/mosdns/lib.sh logfile")
+    clear_file_content(log_file_path)
 end

--- a/luci-app-mosdns/luasrc/model/cbi/mosdns/basic.lua
+++ b/luci-app-mosdns/luasrc/model/cbi/mosdns/basic.lua
@@ -1,86 +1,94 @@
-m = Map("mosdns")
-m.title = translate("MosDNS")
+-- Function to add remote DNS values
+local function add_remote_dns_values(remote_dns)
+  remote_dns:value("tls://8.8.8.8", "8.8.8.8 (Google DNS)")
+  remote_dns:value("tls://8.8.4.4", "8.8.4.4 (Google DNS)")
+  remote_dns:value("tls://1.1.1.1", "1.1.1.1 (CloudFlare DNS)")
+  remote_dns:value("tls://1.0.0.1", "1.0.0.1 (CloudFlare DNS)")
+  remote_dns:value("tls://101.101.101.101", "101.101.101.101 (Quad101 DNS)")
+  remote_dns:value("tls://9.9.9.11", "9.9.9.11 (Quad9 DNS)")
+  remote_dns:value("tls://149.112.112.11", "149.112.112.11 (Quad9 DNS)")
+  remote_dns:value("tls://208.67.222.222", "208.67.222.222 (Open DNS)")
+  remote_dns:value("tls://208.67.220.220", "208.67.220.220 (Open DNS)")
+  remote_dns:value("tls://94.140.14.140", "94.140.14.140 (AdGuard)")
+  remote_dns:value("tls://94.140.14.141", "94.140.14.141 (AdGuard)")
+end
+
+-- Create the map
+local m = Map("mosdns", translate("MosDNS"))
 m.description = translate("MosDNS is a 'programmable' DNS forwarder.")
 
-m:section(SimpleSection).template = "mosdns/mosdns_status"
+-- Add the status section
+local s = m:section(SimpleSection)
+s.template = "mosdns/mosdns_status"
 
+-- Add the main section
 s = m:section(TypedSection, "mosdns")
 s.addremove = false
 s.anonymous = true
 
-enable = s:option(Flag, "enabled", translate("Enable"))
+-- Enable option
+local enable = s:option(Flag, "enabled", translate("Enable"))
 enable.rmempty = false
 
-configfile = s:option(ListValue, "configfile", translate("MosDNS Config File"))
+-- Config file option
+local configfile = s:option(ListValue, "configfile", translate("MosDNS Config File"))
 configfile:value("./def_config.yaml", translate("Def Config"))
 configfile:value("./cus_config.yaml", translate("Cus Config"))
 configfile.default = "./def_config.yaml"
 
-listenport = s:option(Value, "listen_port", translate("Listen port"))
+-- Listen port option
+local listenport = s:option(Value, "listen_port", translate("Listen port"))
 listenport.datatype = "and(port,min(1))"
 listenport.default = 5335
-listenport:depends( "configfile", "./def_config.yaml")
+listenport:depends("configfile", "./def_config.yaml")
 
-loglv = s:option(ListValue, "loglv", translate("Log Level"))
+-- Log level option
+local loglv = s:option(ListValue, "loglv", translate("Log Level"))
 loglv:value("debug", translate("Debug"))
 loglv:value("info", translate("Info"))
 loglv:value("warn", translate("Warning"))
 loglv:value("error", translate("Error"))
 loglv.default = "error"
-loglv:depends( "configfile", "./def_config.yaml")
+loglv:depends("configfile", "./def_config.yaml")
 
-logfile = s:option(Value, "logfile", translate("MosDNS Log File"))
+-- Log file option
+local logfile = s:option(Value, "logfile", translate("MosDNS Log File"))
 logfile.placeholder = "/tmp/mosdns.txt"
 logfile.default = "/tmp/mosdns.txt"
-logfile:depends( "configfile", "./def_config.yaml")
+logfile:depends("configfile", "./def_config.yaml")
 
-remote_dns = s:option(Value, "remote_dns1", translate("Remote DNS"))
+-- Remote DNS options
+local remote_dns = s:option(Value, "remote_dns1", translate("Remote DNS"))
 remote_dns.default = "tls://1.0.0.1"
-remote_dns:value("tls://8.8.8.8", "8.8.8.8 (Google DNS)")
-remote_dns:value("tls://8.8.4.4", "8.8.4.4 (Google DNS)")
-remote_dns:value("tls://1.1.1.1", "1.1.1.1 (CloudFlare DNS)")
-remote_dns:value("tls://1.0.0.1", "1.0.0.1 (CloudFlare DNS)")
-remote_dns:value("tls://101.101.101.101", "101.101.101.101 (Quad101 DNS)")
-remote_dns:value("tls://9.9.9.11", "9.9.9.11 (Quad9 DNS)")
-remote_dns:value("tls://149.112.112.11", "149.112.112.11 (Quad9 DNS)")
-remote_dns:value("tls://208.67.222.222", "208.67.222.222 (Open DNS)")
-remote_dns:value("tls://208.67.220.220", "208.67.220.220 (Open DNS)")
-remote_dns:value("tls://94.140.14.140", "94.140.14.140 (AdGuard)")
-remote_dns:value("tls://94.140.14.141", "94.140.14.141 (AdGuard)")
-remote_dns:depends( "configfile", "./def_config.yaml")
-remote_dns = s:option(Value, "remote_dns2", "ㅤ")
-remote_dns.default = "tls://208.67.220.220"
-remote_dns:value("tls://8.8.8.8", "8.8.8.8 (Google DNS)")
-remote_dns:value("tls://8.8.4.4", "8.8.4.4 (Google DNS)")
-remote_dns:value("tls://1.1.1.1", "1.1.1.1 (CloudFlare DNS)")
-remote_dns:value("tls://1.0.0.1", "1.0.0.1 (CloudFlare DNS)")
-remote_dns:value("tls://101.101.101.101", "101.101.101.101 (Quad101 DNS)")
-remote_dns:value("tls://9.9.9.11", "9.9.9.11 (Quad9 DNS)")
-remote_dns:value("tls://149.112.112.11", "149.112.112.11 (Quad9 DNS)")
-remote_dns:value("tls://208.67.222.222", "208.67.222.222 (Open DNS)")
-remote_dns:value("tls://208.67.220.220", "208.67.220.220 (Open DNS)")
-remote_dns:value("tls://94.140.14.140", "94.140.14.140 (AdGuard)")
-remote_dns:value("tls://94.140.14.141", "94.140.14.141 (AdGuard)")
-remote_dns:depends( "configfile", "./def_config.yaml")
+remote_dns:depends("configfile", "./def_config.yaml")
+add_remote_dns_values(remote_dns)
 
-redirect = s:option(Flag, "redirect", translate("Enable DNS Redirect"))
-redirect:depends( "configfile", "./def_config.yaml")
+local remote_dns2 = s:option(Value, "remote_dns2", "ㅤ")
+remote_dns2.default = "tls://208.67.220.220"
+remote_dns2:depends("configfile", "./def_config.yaml")
+add_remote_dns_values(remote_dns2)
+
+-- DNS Redirect option
+local redirect = s:option(Flag, "redirect", translate("Enable DNS Redirect"))
+redirect:depends("configfile", "./def_config.yaml")
 redirect.default = true
 
-adblock = s:option(Flag, "adblock", translate("Enable DNS ADblock"))
-adblock:depends( "configfile", "./def_config.yaml")
+-- DNS ADblock option
+local adblock = s:option(Flag, "adblock", translate("Enable DNS ADblock"))
 adblock.default = false
 
-set_config = s:option(Button, "set_config", translate("DNS Helper"))
+-- DNS Helper button
+local set_config = s:option(Button, "set_config", translate("DNS Helper"))
 set_config.inputtitle = translate("Apply")
 set_config.inputstyle = "reload"
 set_config.description = translate("This will make the necessary adjustments to other plug-in settings.")
 set_config.write = function()
   luci.sys.exec("/etc/mosdns/set.sh &> /dev/null &")
 end
-set_config:depends( "configfile", "./def_config.yaml")
+set_config:depends("configfile", "./def_config.yaml")
 
-unset_config = s:option(Button, "unset_config", translate("Revert Settings"))
+-- Revert Settings button
+local unset_config = s:option(Button, "unset_config", translate("Revert Settings"))
 unset_config.inputtitle = translate("Apply")
 unset_config.inputstyle = "reload"
 unset_config.description = translate("This will revert the adjustments.")

--- a/luci-app-mosdns/luasrc/model/cbi/mosdns/log.lua
+++ b/luci-app-mosdns/luasrc/model/cbi/mosdns/log.lua
@@ -1,5 +1,3 @@
-m = Map("mosdns")
-
+local m = Map("mosdns")
 m:append(Template("mosdns/mosdns_log"))
-
 return m

--- a/luci-app-mosdns/luasrc/model/cbi/mosdns/rule_list.lua
+++ b/luci-app-mosdns/luasrc/model/cbi/mosdns/rule_list.lua
@@ -1,10 +1,34 @@
 local datatypes = require "luci.cbi.datatypes"
 
-local white_list_file = "/etc/mosdns/rule/whitelist.txt"
-local block_list_file = "/etc/mosdns/rule/blocklist.txt"
-local hosts_list_file = "/etc/mosdns/rule/hosts.txt"
-local redirect_list_file = "/etc/mosdns/rule/redirect.txt"
-local cus_config_file = "/etc/mosdns/cus_config.yaml"
+local rule_files = {
+  white_list = "/etc/mosdns/rule/whitelist.txt",
+  block_list = "/etc/mosdns/rule/blocklist.txt",
+  hosts_list = "/etc/mosdns/rule/hosts.txt",
+  redirect_list = "/etc/mosdns/rule/redirect.txt",
+  cus_config = "/etc/mosdns/cus_config.yaml"
+}
+
+local function read_file(file_path)
+  local file = io.open(file_path, "r")
+  if file then
+    local content = file:read("*a")
+    file:close()
+    return content
+  end
+  return ""
+end
+
+local function write_file(file_path, content)
+  local file = io.open(file_path, "w")
+  if file then
+    file:write(content)
+    file:close()
+  end
+end
+
+local function remove_file(file_path)
+  write_file(file_path, "")
+end
 
 m = Map("mosdns")
 
@@ -20,56 +44,56 @@ s:tab("cus_config", translate("Cus Config"))
 o = s:taboption("white_list", TextValue, "whitelist", "", "<font color='red'>" .. translate("These domain names allow DNS resolution with the highest priority. Please input the domain names of websites, every line can input only one website domain. For example: hm.baidu.com.") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
 o.rows = 15
 o.wrap = "off"
-o.cfgvalue = function(self, section) return nixio.fs.readfile(white_list_file) or "" end
-o.write = function(self, section, value) nixio.fs.writefile(white_list_file , value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) nixio.fs.writefile(white_list_file , "") end
+o.cfgvalue = function(self, section) return read_file(rule_files.white_list) end
+o.write = function(self, section, value) write_file(rule_files.white_list, value:gsub("\r\n", "\n")) end
+o.remove = function(self, section, value) remove_file(rule_files.white_list) end
 o.validate = function(self, value)
-    return value
+  return value
 end
 
 o = s:taboption("block_list", TextValue, "blocklist", "", "<font color='red'>" .. translate("These domains are blocked from DNS resolution. Please input the domain names of websites, every line can input only one website domain. For example: baidu.com.") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
 o.rows = 15
 o.wrap = "off"
-o.cfgvalue = function(self, section) return nixio.fs.readfile(block_list_file) or "" end
-o.write = function(self, section, value) nixio.fs.writefile(block_list_file, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) nixio.fs.writefile(block_list_file, "") end
+o.cfgvalue = function(self, section) return read_file(rule_files.block_list) end
+o.write = function(self, section, value) write_file(rule_files.block_list, value:gsub("\r\n", "\n")) end
+o.remove = function(self, section, value) remove_file(rule_files.block_list) end
 o.validate = function(self, value)
-    return value
+  return value
 end
 
 o = s:taboption("hosts_list", TextValue, "hosts", "", "<font color='red'>" .. translate("Hosts For example: baidu.com 10.0.0.1") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
 o.rows = 15
 o.wrap = "off"
-o.cfgvalue = function(self, section) return nixio.fs.readfile(hosts_list_file) or "" end
-o.write = function(self, section, value) nixio.fs.writefile(hosts_list_file, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) nixio.fs.writefile(hosts_list_file, "") end
+o.cfgvalue = function(self, section) return read_file(rule_files.hosts_list) end
+o.write = function(self, section, value) write_file(rule_files.hosts_list, value:gsub("\r\n", "\n")) end
+o.remove = function(self, section, value) remove_file(rule_files.hosts_list) end
 o.validate = function(self, value)
-    return value
+  return value
 end
 
 o = s:taboption("redirect_list", TextValue, "redirect", "", "<font color='red'>" .. translate("The domain name to redirect the request to. Requests domain A, but returns records for domain B. example: a.com b.com") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
 o.rows = 15
 o.wrap = "off"
-o.cfgvalue = function(self, section) return nixio.fs.readfile(redirect_list_file) or "" end
-o.write = function(self, section, value) nixio.fs.writefile(redirect_list_file, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) nixio.fs.writefile(redirect_list_file, "") end
+o.cfgvalue = function(self, section) return read_file(rule_files.redirect_list) end
+o.write = function(self, section, value) write_file(rule_files.redirect_list, value:gsub("\r\n", "\n")) end
+o.remove = function(self, section, value) remove_file(rule_files.redirect_list) end
 o.validate = function(self, value)
-    return value
+  return value
 end
 
 o = s:taboption("cus_config", TextValue, "Cus Config", "", "<font color='red'>" .. translate("View the Custom YAML Configuration file used by this MosDNS. You can edit it as you own need.") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Custom Config' profiles.") .. "</font>")
 o.rows = 30
 o.wrap = "off"
-o.cfgvalue = function(self, section) return nixio.fs.readfile(cus_config_file) or "" end
-o.write = function(self, section, value) nixio.fs.writefile(cus_config_file, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) nixio.fs.writefile(cus_config_file, "") end
+o.cfgvalue = function(self, section) return read_file(rule_files.cus_config) end
+o.write = function(self, section, value) write_file(rule_files.cus_config, value:gsub("\r\n", "\n")) end
+o.remove = function(self, section, value) remove_file(rule_files.cus_config) end
 o.validate = function(self, value)
-    return value
+  return value
 end
 
 local apply = luci.http.formvalue("cbi.apply")
 if apply then
-    luci.sys.exec("/etc/init.d/mosdns reload")
+  luci.sys.exec("/etc/init.d/mosdns reload")
 end
 
 return m

--- a/luci-app-mosdns/luasrc/model/cbi/mosdns/update.lua
+++ b/luci-app-mosdns/luasrc/model/cbi/mosdns/update.lua
@@ -1,37 +1,41 @@
-m = Map("mosdns")
+local m = Map("mosdns")
 
-s = m:section(TypedSection, "mosdns", translate("Geodata Update"))
+local s = m:section(TypedSection, "mosdns", translate("Geodata Update"))
 s.addremove = false
 s.anonymous = true
 
-enable = s:option(Flag, "geo_auto_update", translate("Enable Auto Database Update"))
-enable.rmempty = false
+local enable_auto_update = s:option(Flag, "geo_auto_update", translate("Enable Auto Database Update"))
+enable_auto_update.rmempty = false
 
-enable = s:option(Flag, "syncconfig", translate("Enable Config Update"))
-enable.rmempty = false
+local enable_config_update = s:option(Flag, "syncconfig", translate("Enable Config Update"))
+enable_config_update.rmempty = false
 
-o = s:option(ListValue, "geo_update_week_time", translate("Update Cycle"))
-o:value("*", translate("Every Day"))
-o:value("1", translate("Every Monday"))
-o:value("2", translate("Every Tuesday"))
-o:value("3", translate("Every Wednesday"))
-o:value("4", translate("Every Thursday"))
-o:value("5", translate("Every Friday"))
-o:value("6", translate("Every Saturday"))
-o:value("7", translate("Every Sunday"))
-o.default = "*"
+local update_cycle = s:option(ListValue, "geo_update_week_time", translate("Update Cycle"))
+update_cycle:value("*", translate("Every Day"))
+update_cycle:value("1", translate("Every Monday"))
+update_cycle:value("2", translate("Every Tuesday"))
+update_cycle:value("3", translate("Every Wednesday"))
+update_cycle:value("4", translate("Every Thursday"))
+update_cycle:value("5", translate("Every Friday"))
+update_cycle:value("6", translate("Every Saturday"))
+update_cycle:value("7", translate("Every Sunday"))
+update_cycle.default = "*"
 
-update_time = s:option(ListValue, "geo_update_day_time", translate("Update Time (Every Day)"))
+local update_time = s:option(ListValue, "geo_update_day_time", translate("Update Time (Every Day)"))
 for t = 0, 23 do
-  update_time:value(t, t..":00")
+  update_time:value(tostring(t), t .. ":00")
 end
-update_time.default = 0
+update_time.default = "0"
 
-data_update = s:option(Button, "geo_update_database", translate("Database Update"))
+local proxy_url = s:option(Value, "proxy_url", translate("Proxy URL"))
+proxy_url.default = ""
+proxy_url.rmempty = true
+
+local data_update = s:option(Button, "geo_update_database", translate("Database Update"))
 data_update.inputtitle = translate("Check And Update")
 data_update.inputstyle = "reload"
 data_update.write = function()
-  luci.sys.exec("/etc/mosdns/mosupdater.sh &> /dev/null &")
+  luci.sys.exec("/etc/mosdns/mosupdater.sh > /dev/null 2>&1 &")
 end
 
 return m

--- a/luci-app-mosdns/luasrc/view/mosdns/mosdns_log.htm
+++ b/luci-app-mosdns/luasrc/view/mosdns/mosdns_log.htm
@@ -1,29 +1,60 @@
 <script type="text/javascript">
-	//<![CDATA[
-	function clear_log(btn) {
-		XHR.get('<%=url([[admin]], [[services]], [[mosdns]], [[clear_log]])%>', null,
-			function(x, data) {
-				if(x && x.status == 200) {
-					var log_textarea = document.getElementById('log_textarea');
-					log_textarea.innerHTML = "";
-					log_textarea.scrollTop = log_textarea.scrollHeight;
-				}
-				location.reload();
-			}
-		);
-	}
-	XHR.poll(1, '<%=url([[admin]], [[services]], [[mosdns]], [[get_log]])%>', null,
-		function(x, data) {
-			if(x && x.status == 200) {
-				var log_textarea = document.getElementById('log_textarea');
-				log_textarea.innerHTML = x.responseText;
-				log_textarea.scrollTop = log_textarea.scrollHeight;
-			}
+	document.addEventListener('DOMContentLoaded', function() {
+		const clearLogButton = document.getElementById('clear_log_button');
+		const logTextarea = document.getElementById('log_textarea');
+
+		clearLogButton.addEventListener('click', clearLog);
+
+		getLog();
+		setInterval(getLog, 1000);
+
+		function clearLog() {
+			clearLogButton.disabled = true;
+
+			fetch('<%=url([[admin]], [[services]], [[mosdns]], [[clear_log]])%>', { method: 'GET' })
+				.then(function(response) {
+					if (response.ok) {
+						clearLogTextarea();
+						location.reload();
+					} else {
+						throw new Error('Network response was not ok.');
+					}
+				})
+				.catch(function(error) {
+					console.error('Error:', error);
+					clearLogButton.disabled = false;
+				});
 		}
-	);
-	//]]>
+
+		function clearLogTextarea() {
+			logTextarea.innerHTML = '';
+			logTextarea.scrollTop = logTextarea.scrollHeight;
+		}
+
+		function getLog() {
+			fetch('<%=url([[admin]], [[services]], [[mosdns]], [[get_log]])%>', { method: 'GET' })
+				.then(function(response) {
+					if (response.ok) {
+						return response.text();
+					} else {
+						throw new Error('Network response was not ok.');
+					}
+				})
+				.then(function(logText) {
+					updateLogTextarea(logText);
+				})
+				.catch(function(error) {
+					console.error('Error:', error);
+				});
+		}
+
+		function updateLogTextarea(logText) {
+			logTextarea.innerHTML = logText;
+			logTextarea.scrollTop = logTextarea.scrollHeight;
+		}
+	});
 </script>
 <fieldset class="cbi-section" id="_log_fieldset">
-	<input class="cbi-button cbi-input-remove" type="button" onclick="clear_log()" value="<%:Clear logs%>" style="margin-left: 10px; margin-top: 10px;">
-	<textarea id="log_textarea" class="cbi-input-textarea" style="width: calc(100% - 20px); height: 600px; margin: 10px;" data-update="change" rows="5" wrap="off" readonly="readonly"></textarea>
+	<input id="clear_log_button" class="cbi-button cbi-input-remove" type="button" value="<%:Clear logs%>" style="margin-left: 10px; margin-top: 10px;">
+	<textarea id="log_textarea" class="cbi-input-textarea" style="width: calc(100% - 20px); height: 600px; margin: 10px;" data-update="change" rows="5" wrap="off" readonly></textarea>
 </fieldset>

--- a/luci-app-mosdns/luasrc/view/mosdns/mosdns_status.htm
+++ b/luci-app-mosdns/luasrc/view/mosdns/mosdns_status.htm
@@ -1,28 +1,47 @@
-<script type="text/javascript">
-	//<![CDATA[
-	XHR.poll(3, '<%=url([[admin]], [[services]], [[mosdns]], [[status]])%>', null,
-		function(x, data) {
-			var tb = document.getElementById('mosdns_status');
-			if (data && tb) {
-				if (data.running) {
-					var links = '<em><b style=color:green>MosDNS <%:RUNNING%></b></em>';
-					tb.innerHTML = links;
-				} else {
-					tb.innerHTML = '<em><b style=color:red>MosDNS <%:NOT RUNNING%></b></em>';
-				}
-			}
-		}
-	);
-	//]]>
-</script>
 <style>
-	.mar-10 {
-		margin-left: 50px;
-		margin-right: 10px;
-	}
+    .mar-10 {
+        margin-left: 50px;
+        margin-right: 10px;
+    }
 </style>
+
 <fieldset class="cbi-section">
-	<p id="mosdns_status">
-		<em><%:Collecting data...%></em>
-	</p>
+    <p id="mosdns_status">
+        <em><%:Collecting data...%></em>
+    </p>
 </fieldset>
+
+<script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', async function() {
+        const tb = document.getElementById('mosdns_status');
+
+        async function fetchMosDNSStatus() {
+            try {
+                const response = await fetch('<%=url([[admin]], [[services]], [[mosdns]], [[status]])%>');
+                const data = await response.json();
+                return data;
+            } catch (error) {
+                console.error('Error:', error);
+                throw error;
+            }
+        }
+
+        function updateMosDNSStatus() {
+            fetchMosDNSStatus()
+                .then(data => {
+                    const statusText = data && data.running ? 'MosDNS <%:RUNNING%>' : 'MosDNS <%:NOT RUNNING%>';
+                    const statusColor = data && data.running ? 'green' : 'red';
+                    tb.innerHTML = `<em><b style="color:${statusColor}">${statusText}</b></em>`;
+                })
+                .catch(() => {
+                    tb.innerHTML = '<em><b style="color:red">Failed to fetch MosDNS status</b></em>';
+                });
+        }
+
+        // Call the function initially
+        await updateMosDNSStatus();
+
+        // Call the function every 3 seconds
+        setInterval(updateMosDNSStatus, 3000);
+    });
+</script>

--- a/luci-app-mosdns/po/zh-cn/mosdns.po
+++ b/luci-app-mosdns/po/zh-cn/mosdns.po
@@ -61,6 +61,9 @@ msgstr "每周六"
 msgid "Every Sunday"
 msgstr "每周日"
 
+msgid "Proxy URL"
+msgstr "代理地址"
+
 msgid "Database Update"
 msgstr "数据库更新"
 

--- a/luci-app-mosdns/root/etc/hotplug.d/iface/65-mosdns
+++ b/luci-app-mosdns/root/etc/hotplug.d/iface/65-mosdns
@@ -1,2 +1,5 @@
 #!/bin/sh
-[ "$ACTION" = ifup ] && /etc/init.d/mosdns restart
+
+if [ "$ACTION" = "ifup" ]; then
+    /etc/init.d/mosdns restart
+fi

--- a/luci-app-mosdns/root/etc/init.d/mosdns
+++ b/luci-app-mosdns/root/etc/init.d/mosdns
@@ -16,6 +16,7 @@ inital_conf() {
   config_load "mosdns"
   config_get "enabled" "mosdns" "enabled" "0"
 }
+
 service_triggers() {
   procd_add_reload_trigger "mosdns"
 }
@@ -51,26 +52,28 @@ restart_others() {
 reload_service() {
   stop
   sleep 2s
-  echo "MosDNS is restarted!"
+  printf "MosDNS is restarted!\n"
   start
 }
 
 setcron() {
-  touch $CRON_FILE
-  sed -i '/mosupdater.sh/d' $CRON_FILE 2> /dev/null
-  [ "$(uci -q get mosdns.mosdns.geo_auto_update)" -eq 1 ] && echo "0 $(uci -q get mosdns.mosdns.geo_update_day_time) * * $(uci -q get mosdns.mosdns.geo_update_week_time) /etc/mosdns/mosupdater.sh" >> $CRON_FILE
-  crontab $CRON_FILE
+  touch "$CRON_FILE"
+  sed -i '/mosupdater.sh/d' "$CRON_FILE" 2>/dev/null
+  if [ "$(uci -q get mosdns.mosdns.geo_auto_update)" -eq 1 ]; then
+    echo "0 $(uci -q get mosdns.mosdns.geo_update_day_time) * * $(uci -q get mosdns.mosdns.geo_update_week_time) /etc/mosdns/mosupdater.sh" >> "$CRON_FILE"
+  fi
+  crontab "$CRON_FILE"
 }
 
 delcron() {
-  sed -i '/mosupdater.sh/d' $CRON_FILE 2> /dev/null
-  crontab $CRON_FILE
+  sed -i '/mosupdater.sh/d' "$CRON_FILE" 2>/dev/null
+  crontab "$CRON_FILE"
 }
 
 adblock() {
   cp -f /etc/mosdns/rule/serverlist.txt /etc/mosdns/rule/serverlist.bak
   modns_adblock=$(uci -q get mosdns.mosdns.adblock)
-  if [ "$modns_adblock" = 0 ]; then
+  if [ "$modns_adblock" -eq 0 ]; then
     : > /etc/mosdns/rule/serverlist.txt
   else
     cat /etc/mosdns/rule/serverlist.bak > /etc/mosdns/rule/serverlist.txt
@@ -90,29 +93,27 @@ v4config() {
 }
 
 start_service() {
-
   # Reading config
   inital_conf
   if [ "$enabled" -eq 0 ]; then
-    echo "MosDNS has turned off"
+    printf "MosDNS has turned off\n"
     return 1
   fi
   delcron
   setcron
   adblock
-  true > "$(/etc/mosdns/lib.sh logfile)"
+  true >"$(/etc/mosdns/lib.sh logfile)"
   sysctl -w net.core.rmem_max=2500000
   v4config
   procd_open_instance mosdns
-  procd_set_param command $PROG start -d $RES_DIR -c "$CONF"
+  procd_set_param command "$PROG" start -d "$RES_DIR" -c "$CONF"
   procd_set_param user root
   procd_set_param stdout 1
   procd_set_param stderr 1
   procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
   procd_close_instance mosdns
 
-  configfile=$(uci -q get mosdns.mosdns.configfile)
-  if [ "${configfile}" = "./def_config.yaml" ]; then
+  if [ "$(uci -q get mosdns.mosdns.configfile)" = "./def_config.yaml" ]; then
     restore_setting
     prepare_setting
     if [ "$(uci -q get mosdns.mosdns.redirect)" -eq 1 ] && [ "$(uci -q get shadowsocksr.@global[0].run_mode)" != gfw ]; then
@@ -125,24 +126,22 @@ start_service() {
     restart_others
   fi
 
-  echo "MosDNS turn on"
-  echo "enabled=$enabled"
-
+  printf "MosDNS turn on\n"
+  printf "enabled=%d\n" "$enabled"
 }
 
 stop_service() {
-
   pgrep -f /usr/bin/mosdns | xargs kill -9
-  echo "MosDNS turn off"
-  echo "enabled=$enabled"
+  printf "MosDNS turn off\n"
+  printf "enabled=%d\n" "$enabled"
 
-  configfile=$(uci -q get mosdns.mosdns.configfile)
-  if [ "${configfile}" = "./def_config.yaml" ]; then
+  if [ "$(uci -q get mosdns.mosdns.configfile)" = "./def_config.yaml" ]; then
     config_load "mosdns"
     enabled=$(uci -q get mosdns.mosdns.enabled)
-    [ "${enabled}" = "0" ] && [ "$(uci -q get dhcp.@dnsmasq[0].setbymosdns)" -eq 1 ] && restore_setting
+    if [ "$enabled" = "0" ] && [ "$(uci -q get dhcp.@dnsmasq[0].setbymosdns)" -eq 1 ]; then
+      restore_setting
+    fi
     restart_others
   fi
   delcron
-
 }

--- a/luci-app-mosdns/root/etc/mosdns/mosupdater.sh
+++ b/luci-app-mosdns/root/etc/mosdns/mosupdater.sh
@@ -1,20 +1,27 @@
 #!/bin/bash -e
-# shellcheck source=/dev/null
 set -o pipefail
 source /etc/mosdns/lib.sh
 
+cleanup_tmpdir() {
+  [ -d "$1" ] && rm -rf "$1"
+}
+
 TMPDIR=$(mktemp -d) || exit 1
+
 getdat geosite_cn.txt
 getdat geosite_no_cn.txt
 getdat geoip_cn.txt
+
 if [ "$(grep -o cn "$TMPDIR"/geosite_cn.txt | wc -l)" -lt 100 ]; then
-  rm -rf "$TMPDIR"/geosite_cn.txt
+  cleanup_tmpdir "$TMPDIR"/geosite_cn.txt
 fi
+
 if [ "$(grep -o google "$TMPDIR"/geosite_no_cn.txt | wc -l)" -eq 0 ]; then
-  rm -rf "$TMPDIR"/geosite_no_cn.txt
+  cleanup_tmpdir "$TMPDIR"/geosite_no_cn.txt
 fi
+
 cp -rf "$TMPDIR"/* /etc/mosdns/rule
-rm -rf "$TMPDIR"
+cleanup_tmpdir "$TMPDIR"
 
 syncconfig=$(uci -q get mosdns.mosdns.syncconfig)
 if [ "$syncconfig" -eq 1 ]; then
@@ -22,12 +29,13 @@ if [ "$syncconfig" -eq 1 ]; then
   getdat def_config_v5.yaml
 
   if [ "$(grep -o plugin "$TMPDIR"/def_config_v5.yaml | wc -l)" -eq 0 ]; then
-    rm -rf "$TMPDIR"/def_config_v5.yaml
+    cleanup_tmpdir "$TMPDIR"/def_config_v5.yaml
   else
     mv "$TMPDIR"/def_config_v5.yaml "$TMPDIR"/def_config_orig.yaml
   fi
+
   cp -rf "$TMPDIR"/* /etc/mosdns
-  rm -rf "$TMPDIR"
+  cleanup_tmpdir "$TMPDIR"
 fi
 
 adblock=$(uci -q get mosdns.mosdns.adblock)
@@ -36,10 +44,12 @@ if [ "$adblock" -eq 1 ]; then
   getdat serverlist.txt
 
   if [ "$(grep -o .com "$TMPDIR"/serverlist.txt | wc -l)" -lt 1000 ]; then
-    rm -rf "$TMPDIR"/serverlist.txt
+    cleanup_tmpdir "$TMPDIR"/serverlist.txt
   fi
+
   cp -rf "$TMPDIR"/* /etc/mosdns/rule
-  rm -rf /etc/mosdns/rule/serverlist.bak "$TMPDIR"
+  cleanup_tmpdir /etc/mosdns/rule/serverlist.bak
+  cleanup_tmpdir "$TMPDIR"
 fi
 
 exit 0

--- a/luci-app-mosdns/root/etc/mosdns/set.sh
+++ b/luci-app-mosdns/root/etc/mosdns/set.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck source=/dev/null
 source /etc/mosdns/lib.sh
 
 if uci_ext ssrp; then
@@ -17,10 +16,9 @@ if uci_ext ssrp; then
     fi
   fi
   uci commit shadowsocksr
-  if [ "$(pid ssrplus)" ]; then
-    /etc/init.d/shadowsocksr restart
-  fi
+  [ "$(pid ssrplus)" ] && /etc/init.d/shadowsocksr restart
 fi
+
 if uci_ext pw; then
   if [ "$1" = "unset" ]; then
     uci set passwall.@global[0].dns_mode='dns2tcp'
@@ -36,9 +34,7 @@ if uci_ext pw; then
     uci del passwall.@global[0].chinadns_ng
   fi
   uci commit passwall
-  if [ "$(pid passwall)" ]; then
-    /etc/init.d/passwall restart
-  fi
+  [ "$(pid passwall)" ] && /etc/init.d/passwall restart
 fi
 
 if uci_ext pw2; then
@@ -55,9 +51,7 @@ if uci_ext pw2; then
     uci set passwall2.@global[0].dns_query_strategy='UseIP'
   fi
   uci commit passwall2
-  if [ "$(pid passwall2)" ]; then
-    /etc/init.d/passwall2 restart
-  fi
+  [ "$(pid passwall2)" ] && /etc/init.d/passwall2 restart
 fi
 
 if uci_ext vssr; then
@@ -67,9 +61,7 @@ if uci_ext vssr; then
     uci set vssr.@global[0].pdnsd_enable='0'
   fi
   uci commit vssr
-  if [ "$(pid vssr)" ]; then
-    /etc/init.d/vssr restart
-  fi
+  [ "$(pid vssr)" ] && /etc/init.d/vssr restart
 fi
 
 exit 0

--- a/luci-app-mosdns/root/etc/uci-defaults/luci-mosdns
+++ b/luci-app-mosdns/root/etc/uci-defaults/luci-mosdns
@@ -7,5 +7,5 @@ uci -q batch <<-EOF >/dev/null
 	commit ucitrack
 EOF
 
-rm -rf /tmp/luci-*
+rm -rf /tmp/luci-* || true
 exit 0


### PR DESCRIPTION
使用GPT重构了大量的代码，让代码更规范更现代化。

添加功能：
1. 现在可以在LUCI设置反代地址了，workers.dev在我这不太好用，基本上报废了.
2. 现在你可以在使用“自定义配置”时也能切换“启用 DNS 广告过滤”选项了。