### PR TITLE
重构rule_list.lua、其他一些小修复、清理遗留代码。

### DIFF
--- a/dat/def_config_v5.yaml
+++ b/dat/def_config_v5.yaml
@@ -61,7 +61,7 @@ plugins:
     type: domain_set
     args:
       files:
-        - "/etc/mosdns/rule/serverlist.txt"
+        - "/etc/mosdns/rule/serverlist.act"
 
   # 缓存
   - tag: cache

--- a/luci-app-mosdns/luasrc/controller/mosdns.lua
+++ b/luci-app-mosdns/luasrc/controller/mosdns.lua
@@ -1,27 +1,56 @@
 module("luci.controller.mosdns", package.seeall)
 
+local sys = require("luci.sys")
+local http = require("luci.http")
+local util = require("luci.util")
+
+local function write_json_response(data, content_type)
+    http.prepare_content(content_type)
+    http.write_json(data)
+end
+
+local function handle_file_content(file_path, write)
+    local file = io.open(file_path, write and "r" or "w")
+    if file then
+        local content = file:read("*a")
+        file:close()
+        if write then
+            http.write(content)
+        end
+    end
+end
+
 local function check_config_file()
     return nixio.fs.access("/etc/config/mosdns")
 end
 
-local function prepare_content(content_type)
-    luci.http.prepare_content(content_type)
-end
-
-local function write_json(data)
-    luci.http.write_json(data)
-end
-
-local function write_file_content(file_path)
-    luci.http.write(luci.sys.exec("cat " .. file_path))
-end
-
-local function clear_file_content(file_path)
-    luci.sys.call("true > " .. file_path)
-end
-
 local function is_mosdns_running()
-    return luci.sys.call("pgrep -f mosdns >/dev/null") == 0
+    local result = sys.exec("pgrep -f mosdns")
+    return result ~= ""
+end
+
+function act_status()
+    local status = {
+        running = is_mosdns_running()
+    }
+    write_json_response(status, "application/json")
+end
+
+function get_log()
+    local log_file_path = sys.exec("/etc/mosdns/lib.sh logfile")
+    handle_file_content(log_file_path, true)
+end
+
+function clear_log()
+    local log_file_path = sys.exec("/etc/mosdns/lib.sh logfile")
+    handle_file_content(log_file_path, false)
+end
+
+function reload_mosdns()
+    local output = sys.exec("/etc/init.d/mosdns reload")
+    if output ~= "" then
+        util.perror("Failed to reload MosDNS. Error: " .. output)
+    end
 end
 
 function index()
@@ -80,22 +109,4 @@ function index()
         {"admin", "services", "mosdns", "clear_log"},
         call("clear_log")
     ).leaf = true
-end
-
-function act_status()
-    local status = {
-        running = is_mosdns_running()
-    }
-    prepare_content("application/json")
-    write_json(status)
-end
-
-function get_log()
-    local log_file_path = luci.sys.exec("/etc/mosdns/lib.sh logfile")
-    write_file_content(log_file_path)
-end
-
-function clear_log()
-    local log_file_path = luci.sys.exec("/etc/mosdns/lib.sh logfile")
-    clear_file_content(log_file_path)
 end

--- a/luci-app-mosdns/luasrc/model/cbi/mosdns/basic.lua
+++ b/luci-app-mosdns/luasrc/model/cbi/mosdns/basic.lua
@@ -32,8 +32,8 @@ enable.rmempty = false
 
 -- Config file option
 local configfile = s:option(ListValue, "configfile", translate("MosDNS Config File"))
-configfile:value("./def_config.yaml", translate("Def Config"))
-configfile:value("./cus_config.yaml", translate("Cus Config"))
+configfile:value("./def_config.yaml", translate("Default Config"))
+configfile:value("./cus_config.yaml", translate("Custom Config"))
 configfile.default = "./def_config.yaml"
 
 -- Listen port option

--- a/luci-app-mosdns/luasrc/model/cbi/mosdns/rule_list.lua
+++ b/luci-app-mosdns/luasrc/model/cbi/mosdns/rule_list.lua
@@ -1,99 +1,81 @@
-local datatypes = require "luci.cbi.datatypes"
+local perror = require("luci.util").perror
+local reload_mosdns = require("luci.controller.mosdns").reload_mosdns
 
-local rule_files = {
-  white_list = "/etc/mosdns/rule/whitelist.txt",
-  block_list = "/etc/mosdns/rule/blocklist.txt",
-  hosts_list = "/etc/mosdns/rule/hosts.txt",
-  redirect_list = "/etc/mosdns/rule/redirect.txt",
-  cus_config = "/etc/mosdns/cus_config.yaml"
+local rulePath = {
+  whiteList = "/etc/mosdns/rule/whitelist.txt",
+  blockList = "/etc/mosdns/rule/blocklist.txt",
+  hostsList = "/etc/mosdns/rule/hosts.txt",
+  redirectList = "/etc/mosdns/rule/redirect.txt",
+  cusConfig = "/etc/mosdns/cus_config.yaml"
 }
 
-local function read_file(file_path)
-  local file = io.open(file_path, "r")
-  if file then
-    local content = file:read("*a")
-    file:close()
-    return content
+local function readFile(filePath)
+  local file = io.open(filePath, "r")
+  if not file then
+    perror("Failed to read file: " .. filePath)
+    return ""
   end
-  return ""
+
+  local content = file:read("*a")
+  file:close()
+  return content
 end
 
-local function write_file(file_path, content)
-  local file = io.open(file_path, "w")
-  if file then
-    file:write(content)
-    file:close()
+local function writeFile(filePath, content)
+  local file = io.open(filePath, "w")
+  if not file then
+    perror("Failed to write file: " .. filePath)
+    return
+  end
+
+  file:write(content)
+  file:close()
+end
+
+local function removeFile(filePath)
+  local success, errorMsg = os.remove(filePath)
+  if not success then
+    perror("Failed to remove file: " .. filePath)
   end
 end
 
-local function remove_file(file_path)
-  write_file(file_path, "")
-end
-
-m = Map("mosdns")
-
-s = m:section(TypedSection, "mosdns", translate("Rule Settings"))
+local m = Map("mosdns")
+local s = m:section(TypedSection, "mosdns", translate("Rule Settings"))
 s.anonymous = true
+
+local function createTextOption(tabName, optionName, filePath, description, customDescription, rows, size)
+  local o = s:taboption(tabName, TextValue, optionName, translate(description))
+  o.rows = rows or 15  -- 使用传入的rows参数或默认值15
+  o.size = size or 15  -- 使用传入的width参数或默认值15
+  o.wrap = "off"
+  o.cfgvalue = function(self, section) return readFile(filePath) end
+  o.write = function(self, section, value) writeFile(filePath, value:gsub("\r\n", "\n")) end
+  o.remove = function(self, section, value) removeFile(filePath) end
+  o.validate = function(self, value)
+    return value
+  end
+  o.description = "<font color='#00bd3e'>" .. translate(customDescription or "The rule list applies to both 'Default Config' and 'Custom Config' profiles.") .. "</font>"
+end
 
 s:tab("white_list", translate("White Lists"))
 s:tab("block_list", translate("Block Lists"))
 s:tab("hosts_list", translate("Hosts"))
 s:tab("redirect_list", translate("Redirect"))
-s:tab("cus_config", translate("Cus Config"))
+s:tab("cus_config", translate("Custom Config"))
 
-o = s:taboption("white_list", TextValue, "whitelist", "", "<font color='red'>" .. translate("These domain names allow DNS resolution with the highest priority. Please input the domain names of websites, every line can input only one website domain. For example: hm.baidu.com.") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
-o.rows = 15
-o.wrap = "off"
-o.cfgvalue = function(self, section) return read_file(rule_files.white_list) end
-o.write = function(self, section, value) write_file(rule_files.white_list, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) remove_file(rule_files.white_list) end
-o.validate = function(self, value)
-  return value
-end
+createTextOption("white_list", "whitelist", rulePath.whiteList, "These domain names will be resolved with the highest priority<br> Please input the domain names of websites<br> Each line should contain only one website domain<br>For example: hm.baidu.com")
 
-o = s:taboption("block_list", TextValue, "blocklist", "", "<font color='red'>" .. translate("These domains are blocked from DNS resolution. Please input the domain names of websites, every line can input only one website domain. For example: baidu.com.") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
-o.rows = 15
-o.wrap = "off"
-o.cfgvalue = function(self, section) return read_file(rule_files.block_list) end
-o.write = function(self, section, value) write_file(rule_files.block_list, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) remove_file(rule_files.block_list) end
-o.validate = function(self, value)
-  return value
-end
+createTextOption("block_list", "blocklist", rulePath.blockList, "These domain names are blocked and cannot be resolved through DNS<br>Please input the domain names of websites<br>Each line should contain only one website domain<br>For example: baidu.com")
 
-o = s:taboption("hosts_list", TextValue, "hosts", "", "<font color='red'>" .. translate("Hosts For example: baidu.com 10.0.0.1") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
-o.rows = 15
-o.wrap = "off"
-o.cfgvalue = function(self, section) return read_file(rule_files.hosts_list) end
-o.write = function(self, section, value) write_file(rule_files.hosts_list, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) remove_file(rule_files.hosts_list) end
-o.validate = function(self, value)
-  return value
-end
+createTextOption("hosts_list", "hosts", rulePath.hostsList, "Hosts<br>For example: baidu.com 10.0.0.1")
 
-o = s:taboption("redirect_list", TextValue, "redirect", "", "<font color='red'>" .. translate("The domain name to redirect the request to. Requests domain A, but returns records for domain B. example: a.com b.com") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Default Config' profiles.") .. "</font>")
-o.rows = 15
-o.wrap = "off"
-o.cfgvalue = function(self, section) return read_file(rule_files.redirect_list) end
-o.write = function(self, section, value) write_file(rule_files.redirect_list, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) remove_file(rule_files.redirect_list) end
-o.validate = function(self, value)
-  return value
-end
+createTextOption("redirect_list", "redirect", rulePath.redirectList, "These domain names will be redirected<br>Requests for domain A will return records for domain B<br>For example: a.com b.com")
 
-o = s:taboption("cus_config", TextValue, "Cus Config", "", "<font color='red'>" .. translate("View the Custom YAML Configuration file used by this MosDNS. You can edit it as you own need.") .. "</font>" .. "<font color='#00bd3e'>" .. translate("<br>The list of rules only apply to 'Custom Config' profiles.") .. "</font>")
-o.rows = 30
-o.wrap = "off"
-o.cfgvalue = function(self, section) return read_file(rule_files.cus_config) end
-o.write = function(self, section, value) write_file(rule_files.cus_config, value:gsub("\r\n", "\n")) end
-o.remove = function(self, section, value) remove_file(rule_files.cus_config) end
-o.validate = function(self, value)
-  return value
-end
+createTextOption("cus_config", "cus_config", rulePath.cusConfig, "View the Custom YAML Configuration file used by this MosDNS<br>You can edit it according to your own needs", "The rule list applies exclusively to 'Custom Config' profiles.", 60, 70)
 
 local apply = luci.http.formvalue("cbi.apply")
 if apply then
-  luci.sys.exec("/etc/init.d/mosdns reload")
+  reload_mosdns()
 end
 
 return m

--- a/luci-app-mosdns/luasrc/model/cbi/mosdns/rule_list.lua
+++ b/luci-app-mosdns/luasrc/model/cbi/mosdns/rule_list.lua
@@ -32,13 +32,6 @@ local function writeFile(filePath, content)
   file:close()
 end
 
-local function removeFile(filePath)
-  local success, errorMsg = os.remove(filePath)
-  if not success then
-    perror("Failed to remove file: " .. filePath)
-  end
-end
-
 local m = Map("mosdns")
 local s = m:section(TypedSection, "mosdns", translate("Rule Settings"))
 s.anonymous = true
@@ -50,7 +43,7 @@ local function createTextOption(tabName, optionName, filePath, description, cust
   o.wrap = "off"
   o.cfgvalue = function(self, section) return readFile(filePath) end
   o.write = function(self, section, value) writeFile(filePath, value:gsub("\r\n", "\n")) end
-  o.remove = function(self, section, value) removeFile(filePath) end
+  o.remove = function(self, section, value) writeFile(filePath, "") end
   o.validate = function(self, value)
     return value
   end

--- a/luci-app-mosdns/luasrc/view/mosdns/mosdns_status.htm
+++ b/luci-app-mosdns/luasrc/view/mosdns/mosdns_status.htm
@@ -34,7 +34,8 @@
                     tb.innerHTML = `<em><b style="color:${statusColor}">${statusText}</b></em>`;
                 })
                 .catch(() => {
-                    tb.innerHTML = '<em><b style="color:red">Failed to fetch MosDNS status</b></em>';
+                    const errorMsg = '<em><b style="color:red"><%:Failed to fetch MosDNS status%></b></em>';
+                    tb.innerHTML = errorMsg;
                 });
         }
 

--- a/luci-app-mosdns/po/zh-cn/mosdns.po
+++ b/luci-app-mosdns/po/zh-cn/mosdns.po
@@ -16,6 +16,9 @@ msgstr "未运行"
 msgid "Collecting data..."
 msgstr "获取数据中..."
 
+msgid "Failed to fetch MosDNS status"
+msgstr "无法获取MosDNS状态"
+
 msgid "Enable"
 msgstr "启用"
 
@@ -24,9 +27,6 @@ msgstr "启用 DNS 重定向"
 
 msgid "Enable DNS ADblock"
 msgstr "启用 DNS 广告过滤"
-
-msgid "View the Custom YAML Configuration file used by this MosDNS. You can edit it as you own need."
-msgstr "注意！此页的更改仅当 'MosDNS 配置文件选择' 为 '自定义配置' 时才会生效"
 
 msgid "Geodata Update"
 msgstr "数据库更新"
@@ -97,10 +97,10 @@ msgstr "应用"
 msgid "MosDNS Config File"
 msgstr "MosDNS 配置文件选择"
 
-msgid "Def Config"
-msgstr "内置预设"
+msgid "Default Config"
+msgstr "默认配置"
 
-msgid "Cus Config"
+msgid "Custom Config"
 msgstr "自定义配置"
 
 msgid "Log Level"
@@ -121,32 +121,35 @@ msgstr "规则列表"
 msgid "Rule Settings"
 msgstr "自定义规则列表"
 
-msgid "<br>The list of rules only apply to 'Custom Config' profiles."
-msgstr "<br>规则列表仅适用于 “自定义配置” 配置文件"
+msgid "The rule list applies to both 'Default Config' and 'Custom Config' profiles."
+msgstr "规则列表适用于'默认配置'和'自定义配置'配置文件。"
 
-msgid "<br>The list of rules only apply to 'Default Config' profiles."
-msgstr "<br>规则列表仅适用于 “内置预设” 配置文件"
+msgid "The rule list applies exclusively to 'Custom Config' profiles."
+msgstr "规则列表仅适用于'自定义配置'配置文件。"
 
 msgid "White Lists"
 msgstr "白名单"
 
-msgid "These domain names allow DNS resolution with the highest priority. Please input the domain names of websites, every line can input only one website domain. For example: hm.baidu.com."
-msgstr "加入的域名始终允许 DNS 解析，且优先级最高（每个域名一行，允许使用规则匹配）"
+msgid "These domain names will be resolved with the highest priority<br> Please input the domain names of websites<br> Each line should contain only one website domain<br>For example: hm.baidu.com"
+msgstr "这些域名将以最高优先级进行 DNS 解析<br>请输入网站的域名<br>每行只能包含一个网站域名<br>例如：hm.baidu.com"
 
 msgid "Block Lists"
 msgstr "黑名单"
 
-msgid "These domains are blocked from DNS resolution. Please input the domain names of websites, every line can input only one website domain. For example: baidu.com."
-msgstr "加入的域名将屏蔽 DNS 解析（每个域名一行，允许使用规则匹配）"
+msgid "These domain names are blocked and cannot be resolved through DNS<br>Please input the domain names of websites<br>Each line should contain only one website domain<br>For example: baidu.com"
+msgstr "这些域名被屏蔽，无法进行 DNS 解析<br>请输入网站的域名<br>每行只能包含一个网站域名<br>例如：baidu.com"
 
-msgid "Hosts For example: baidu.com 10.0.0.1"
-msgstr "自定义 Hosts 重写，如：baidu.com 10.0.0.1（每个规则一行）"
+msgid "Hosts<br>For example: baidu.com 10.0.0.1"
+msgstr "Hosts<br>例如：baidu.com 10.0.0.1"
 
 msgid "Redirect"
 msgstr "重定向"
 
-msgid "The domain name to redirect the request to. Requests domain A, but returns records for domain B. example: a.com b.com"
-msgstr "重定向请求的域名。请求域名 A，但返回域名 B 的记录，如：baidu.com qq.com（每个规则一行）"
+msgid "These domain names will be redirected<br>Requests for domain A will return records for domain B<br>For example: a.com b.com"
+msgstr "这些域名将被重定向<br>对于域名 A 的请求将返回域名 B 的记录<br>例如：a.com b.com"
+
+msgid "View the Custom YAML Configuration file used by this MosDNS<br>You can edit it according to your own needs"
+msgstr "查看此 MosDNS 使用的自定义 YAML 配置文件<br>您可以根据自己的需求进行编辑"
 
 msgid "Logs"
 msgstr "日志"

--- a/luci-app-mosdns/root/etc/init.d/mosdns
+++ b/luci-app-mosdns/root/etc/init.d/mosdns
@@ -71,12 +71,24 @@ delcron() {
 }
 
 adblock() {
-  cp -f /etc/mosdns/rule/serverlist.txt /etc/mosdns/rule/serverlist.bak
-  modns_adblock=$(uci -q get mosdns.mosdns.adblock)
-  if [ "$modns_adblock" -eq 0 ]; then
-    : > /etc/mosdns/rule/serverlist.txt
+  local mosdns_adblock=$(uci -q get mosdns.mosdns.adblock)
+  local serverlist_act="/etc/mosdns/rule/serverlist.act"
+  local serverlist_txt="/etc/mosdns/rule/serverlist.txt"
+
+  if [ "$mosdns_adblock" -ne 0 ]; then
+    if [ ! -L "$serverlist_act" ] || [ "$(readlink -f "$serverlist_act")" != "$serverlist_txt" ]; then
+      ln -sf "$serverlist_txt" "$serverlist_act" || {
+        echo "Failed to create symbolic link."
+        return 1
+      }
+    fi
   else
-    cat /etc/mosdns/rule/serverlist.bak > /etc/mosdns/rule/serverlist.txt
+    if [ ! -L "$serverlist_act" ] || [ "$(readlink -f "$serverlist_act")" != "/dev/null" ]; then
+      ln -sf /dev/null "$serverlist_act" || {
+        echo "Failed to create symbolic link."
+        return 1
+      }
+    fi
   fi
 }
 
@@ -96,7 +108,7 @@ start_service() {
   # Reading config
   inital_conf
   if [ "$enabled" -eq 0 ]; then
-    printf "MosDNS has turned off\n"
+    printf "MosDNS has been turned off\n"
     return 1
   fi
   delcron
@@ -126,22 +138,20 @@ start_service() {
     restart_others
   fi
 
-  printf "MosDNS turn on\n"
+  printf "MosDNS turned on\n"
   printf "enabled=%d\n" "$enabled"
 }
 
 stop_service() {
+  inital_conf
   pgrep -f /usr/bin/mosdns | xargs kill -9
-  printf "MosDNS turn off\n"
-  printf "enabled=%d\n" "$enabled"
-
   if [ "$(uci -q get mosdns.mosdns.configfile)" = "./def_config.yaml" ]; then
-    config_load "mosdns"
-    enabled=$(uci -q get mosdns.mosdns.enabled)
     if [ "$enabled" = "0" ] && [ "$(uci -q get dhcp.@dnsmasq[0].setbymosdns)" -eq 1 ]; then
       restore_setting
     fi
     restart_others
   fi
   delcron
+  printf "MosDNS turned off\n"
+  printf "enabled=%d\n" "$enabled"
 }

--- a/luci-app-mosdns/root/etc/init.d/mosdns
+++ b/luci-app-mosdns/root/etc/init.d/mosdns
@@ -32,7 +32,7 @@ restore_setting() {
 
 prepare_setting() {
   redirect=$(uci -q get mosdns.mosdns.redirect)
-  if [ "$redirect" -eq 1 ]; then
+  if [ "$redirect" == "1" ]; then
     sed -i "/list server/d" /etc/config/dhcp
     uci add_list dhcp.@dnsmasq[0].server="127.0.0.1#$(uci -q get mosdns.mosdns.listen_port)"
     uci set dhcp.@dnsmasq[0].rebind_protection='0'
@@ -59,7 +59,7 @@ reload_service() {
 setcron() {
   touch "$CRON_FILE"
   sed -i '/mosupdater.sh/d' "$CRON_FILE" 2>/dev/null
-  if [ "$(uci -q get mosdns.mosdns.geo_auto_update)" -eq 1 ]; then
+  if [ "$(uci -q get mosdns.mosdns.geo_auto_update)" == "1" ]; then
     echo "0 $(uci -q get mosdns.mosdns.geo_update_day_time) * * $(uci -q get mosdns.mosdns.geo_update_week_time) /etc/mosdns/mosupdater.sh" >> "$CRON_FILE"
   fi
   crontab "$CRON_FILE"
@@ -75,7 +75,7 @@ adblock() {
   local serverlist_act="/etc/mosdns/rule/serverlist.act"
   local serverlist_txt="/etc/mosdns/rule/serverlist.txt"
 
-  if [ "$mosdns_adblock" -ne 0 ]; then
+  if [ "$mosdns_adblock" != "0" ]; then
     if [ ! -L "$serverlist_act" ] || [ "$(readlink -f "$serverlist_act")" != "$serverlist_txt" ]; then
       ln -sf "$serverlist_txt" "$serverlist_act" || {
         echo "Failed to create symbolic link."
@@ -107,7 +107,7 @@ v4config() {
 start_service() {
   # Reading config
   inital_conf
-  if [ "$enabled" -eq 0 ]; then
+  if [ "$enabled" == "0" ]; then
     printf "MosDNS has been turned off\n"
     return 1
   fi
@@ -128,7 +128,7 @@ start_service() {
   if [ "$(uci -q get mosdns.mosdns.configfile)" = "./def_config.yaml" ]; then
     restore_setting
     prepare_setting
-    if [ "$(uci -q get mosdns.mosdns.redirect)" -eq 1 ] && [ "$(uci -q get shadowsocksr.@global[0].run_mode)" != gfw ]; then
+    if [ "$(uci -q get mosdns.mosdns.redirect)" == "1" ] && [ "$(uci -q get shadowsocksr.@global[0].run_mode)" != gfw ]; then
       true > /etc/ssrplus/gfw_list.conf
       sed -i '/update.lua/d' /usr/share/shadowsocksr/ssrplusupdate.sh
       sed -i '/bin\/sh/a\/usr/bin/lua /usr/share/shadowsocksr/update.lua ad_data' /usr/share/shadowsocksr/ssrplusupdate.sh
@@ -146,7 +146,7 @@ stop_service() {
   inital_conf
   pgrep -f /usr/bin/mosdns | xargs kill -9
   if [ "$(uci -q get mosdns.mosdns.configfile)" = "./def_config.yaml" ]; then
-    if [ "$enabled" = "0" ] && [ "$(uci -q get dhcp.@dnsmasq[0].setbymosdns)" -eq 1 ]; then
+    if [ "$enabled" = "0" ] && [ "$(uci -q get dhcp.@dnsmasq[0].setbymosdns)" == "1" ]; then
       restore_setting
     fi
     restart_others

--- a/luci-app-mosdns/root/etc/mosdns/def_config_orig.yaml
+++ b/luci-app-mosdns/root/etc/mosdns/def_config_orig.yaml
@@ -1,10 +1,10 @@
 log:
   level: loglvl
   file: "logfile"
-  
+
 # api:
 #   http: "127.0.0.1:8080" # 在该地址启动 api 接口。
-  
+
 plugins:
   # 加载配置
   # 国内域名
@@ -13,7 +13,7 @@ plugins:
     args:
       files:                        # 从文本文件载入
         - "/etc/mosdns/rule/geosite_cn.txt"
-  
+
   # 国内ip
   - tag: geoip_cn
     type: ip_set
@@ -61,7 +61,7 @@ plugins:
     type: domain_set
     args:
       files:
-        - "/etc/mosdns/rule/serverlist.txt"
+        - "/etc/mosdns/rule/serverlist.act"
 
   # 缓存
   - tag: cache
@@ -79,7 +79,7 @@ plugins:
       upstreams:
         - addr: localdns1
         - addr: localdns2
-  
+
   # 转发至远程服务器
   - tag: forward_remote
     type: forward
@@ -102,7 +102,7 @@ plugins:
     args:
       - exec: prefer_ipv4
       - exec: $forward_remote
-  
+
   # 有响应终止返回
   - tag: has_resp_sequence
     type: sequence
@@ -169,7 +169,7 @@ plugins:
         exec: reject 3
       - matches: qtype 65
         exec: reject 3
-  
+
   # 主要的运行逻辑插件
   # sequence 插件中调用的插件 tag 必须在 sequence 前定义，
   # 否则 sequence 找不到对应插件。

--- a/luci-app-mosdns/root/etc/mosdns/mosupdater.sh
+++ b/luci-app-mosdns/root/etc/mosdns/mosupdater.sh
@@ -7,49 +7,22 @@ cleanup_tmpdir() {
 }
 
 TMPDIR=$(mktemp -d) || exit 1
+syncconfig=$(uci -q get mosdns.mosdns.syncconfig)
+adblock=$(uci -q get mosdns.mosdns.adblock)
 
 getdat geosite_cn.txt
 getdat geosite_no_cn.txt
 getdat geoip_cn.txt
 
-if [ "$(grep -o cn "$TMPDIR"/geosite_cn.txt | wc -l)" -lt 100 ]; then
-  cleanup_tmpdir "$TMPDIR"/geosite_cn.txt
-fi
+[ "$adblock" -eq 1 ] && getdat serverlist.txt
 
-if [ "$(grep -o google "$TMPDIR"/geosite_no_cn.txt | wc -l)" -eq 0 ]; then
-  cleanup_tmpdir "$TMPDIR"/geosite_no_cn.txt
+if [ "$syncconfig" -eq 1 ]; then
+  getdat def_config_v5.yaml
+  mv "$TMPDIR"/def_config_v5.yaml "$TMPDIR"/def_config_orig.yaml
+  cp -rf "$TMPDIR"/def_config_orig.yaml /etc/mosdns
 fi
 
 cp -rf "$TMPDIR"/* /etc/mosdns/rule
 cleanup_tmpdir "$TMPDIR"
-
-syncconfig=$(uci -q get mosdns.mosdns.syncconfig)
-if [ "$syncconfig" -eq 1 ]; then
-  TMPDIR=$(mktemp -d) || exit 2
-  getdat def_config_v5.yaml
-
-  if [ "$(grep -o plugin "$TMPDIR"/def_config_v5.yaml | wc -l)" -eq 0 ]; then
-    cleanup_tmpdir "$TMPDIR"/def_config_v5.yaml
-  else
-    mv "$TMPDIR"/def_config_v5.yaml "$TMPDIR"/def_config_orig.yaml
-  fi
-
-  cp -rf "$TMPDIR"/* /etc/mosdns
-  cleanup_tmpdir "$TMPDIR"
-fi
-
-adblock=$(uci -q get mosdns.mosdns.adblock)
-if [ "$adblock" -eq 1 ]; then
-  TMPDIR=$(mktemp -d) || exit 3
-  getdat serverlist.txt
-
-  if [ "$(grep -o .com "$TMPDIR"/serverlist.txt | wc -l)" -lt 1000 ]; then
-    cleanup_tmpdir "$TMPDIR"/serverlist.txt
-  fi
-
-  cp -rf "$TMPDIR"/* /etc/mosdns/rule
-  cleanup_tmpdir /etc/mosdns/rule/serverlist.bak
-  cleanup_tmpdir "$TMPDIR"
-fi
 
 exit 0

--- a/luci-app-mosdns/root/etc/mosdns/mosupdater.sh
+++ b/luci-app-mosdns/root/etc/mosdns/mosupdater.sh
@@ -14,9 +14,9 @@ getdat geosite_cn.txt
 getdat geosite_no_cn.txt
 getdat geoip_cn.txt
 
-[ "$adblock" -eq 1 ] && getdat serverlist.txt
+[ "$adblock" == "1" ] && getdat serverlist.txt
 
-if [ "$syncconfig" -eq 1 ]; then
+if [ "$syncconfig" == "1" ]; then
   getdat def_config_v5.yaml
   mv "$TMPDIR"/def_config_v5.yaml "$TMPDIR"/def_config_orig.yaml
   cp -rf "$TMPDIR"/def_config_orig.yaml /etc/mosdns

--- a/luci-app-mosdns/root/etc/mosdns/set.sh
+++ b/luci-app-mosdns/root/etc/mosdns/set.sh
@@ -6,7 +6,7 @@ if uci_ext ssrp; then
     uci set shadowsocksr.@global[0].pdnsd_enable='1'
     uci set shadowsocksr.@global[0].tunnel_forward="$WAN_DNS0:53"
   elif [ "$1" = "" ]; then
-    if [ "$(uci -q get mosdns.mosdns.listen_port)" -eq 5335 ]; then
+    if [ "$(uci -q get mosdns.mosdns.listen_port)" == "5335" ]; then
       uci set shadowsocksr.@global[0].pdnsd_enable='0'
       uci del shadowsocksr.@global[0].tunnel_forward
       uci del shadowsocksr.@global[0].adblock_url


### PR DESCRIPTION
重构rule_list.lua、减少了初始化脚本的I/O操作、清理更新脚本里的遗留代码。

总之先这样了，由于openwrt在从lua转向JS，本来计划的sh脚本重写为lua就变得意义不大了。
init脚本的I/O减负应该还能进一步，但暂时没动力继续了。

摸了，以后再说吧。